### PR TITLE
feat: Support bound `@classmethod`

### DIFF
--- a/doublex/proxy.py
+++ b/doublex/proxy.py
@@ -209,14 +209,12 @@ class MethodSignature(Signature):
 
     def get_call_args(self, context):
         args = context.args
-        if self.proxy.isclass() and not self.is_classmethod():
+        is_classmethod = self.is_classmethod()
+        if self.proxy.isclass() and not is_classmethod:
             args = (None,) + args  # self
 
         retval = getcallargs(self.method, *args, **context.kargs)
-        if 'self' in retval:
-            del retval['self']
-        if 'cls' in retval and self.is_classmethod():
-            del retval['cls']
+        retval.pop('cls' if is_classmethod else 'self', None)
         return retval
 
     def assure_matches(self, context):

--- a/doublex/proxy.py
+++ b/doublex/proxy.py
@@ -202,14 +202,21 @@ class MethodSignature(Signature):
         del retval.args[0]
         return retval
 
+    def is_classmethod(self):
+        return (
+            inspect.ismethod(self.method) and self.method.__self__ is self.proxy.collaborator_class
+        )
+
     def get_call_args(self, context):
         args = context.args
-        if self.proxy.isclass():
+        if self.proxy.isclass() and not self.is_classmethod():
             args = (None,) + args  # self
 
         retval = getcallargs(self.method, *args, **context.kargs)
         if 'self' in retval:
             del retval['self']
+        if 'cls' in retval and self.is_classmethod():
+            del retval['cls']
         return retval
 
     def assure_matches(self, context):

--- a/doublex/test/unit_tests.py
+++ b/doublex/test/unit_tests.py
@@ -135,6 +135,12 @@ class FreeStubTests(TestCase):
         except SomeException:
             pass
 
+    def test_cls_keyword_works(self):
+        with self.stub:
+            self.stub.foo(cls=2).returns(5)
+
+        assert_that(self.stub.foo(cls=2), is_(5))
+
 
 class StubTests(TestCase):
     def setUp(self):
@@ -215,6 +221,21 @@ class StubTests(TestCase):
             self.stub.hello().returns((3, 4))
 
         assert_that(self.stub.hello(), is_((3, 4)))
+
+    def test_stubbing_classmethod(self):
+        with self.stub:
+            self.stub.class_method().returns(5)
+        assert_that(self.stub.class_method(), is_(5))
+
+    def test_stubbing_classmethod_with_args(self):
+        with self.stub:
+            self.stub.class_method_with_args(2).returns(5)
+        assert_that(self.stub.class_method_with_args(2), is_(5))
+
+    def test_stubbing_method_with_cls_as_arg(self):
+        with self.stub:
+            self.stub.method_with_cls_as_arg(cls=2).returns(5)
+        assert_that(self.stub.method_with_cls_as_arg(cls=2), is_(5))
 
 
 class AccessingActualAttributes(TestCase):
@@ -344,6 +365,11 @@ class FreeSpyTests(TestCase):
         assert_that(self.spy.foo, called().with_args(1).times(2))
         assert_that(self.spy.foo, called().with_args(2))
         assert_that(self.spy.foo, called().times(3))
+
+    def test_cls_keyword_works(self):
+        self.spy.foo(cls=2)
+
+        assert_that(self.spy.foo, called().with_args(cls=2))
 
 #    def test_called_anything_and_value(self):
 #        spy = Spy(Collaborator)
@@ -1824,3 +1850,14 @@ class Collaborator:
         return len(args)
 
     alias_method = one_arg_method
+
+    @classmethod
+    def class_method(cls):
+        pass
+
+    @classmethod
+    def class_method_with_args(cls, *args):
+        pass
+
+    def method_with_cls_as_arg(self, cls):
+        pass

--- a/doublex/test/unit_tests.py
+++ b/doublex/test/unit_tests.py
@@ -190,7 +190,7 @@ class StubTests(TestCase):
         assert_that(self.stub.kwarg_method(key_param=6), is_(6000))
 
     # new on 1.7
-    def test_keyworked_or_positional_are_equivalent(self):
+    def test_keyword_or_positional_are_equivalent(self):
         with self.stub:
             self.stub.kwarg_method(1).returns(1000)
             self.stub.kwarg_method(key_param=6).returns(6000)

--- a/doublex/test/unit_tests.py
+++ b/doublex/test/unit_tests.py
@@ -237,6 +237,11 @@ class StubTests(TestCase):
             self.stub.method_with_cls_as_arg(cls=2).returns(5)
         assert_that(self.stub.method_with_cls_as_arg(cls=2), is_(5))
 
+    def test_stubbing_classmethod_with_self_arg(self):
+        with self.stub:
+            self.stub.class_method_with_self_arg(2).returns(5)
+        assert_that(self.stub.class_method_with_self_arg(2), is_(5))
+
 
 class AccessingActualAttributes(TestCase):
     def test_read_class_attribute_providing_class(self):
@@ -462,6 +467,10 @@ class SpyTests(TestCase):
         self.spy.hello()
         with self.assertRaises(TypeError):
             assert_that(self.spy.hello, called().with_args('some'))
+
+    def test_classmethod_called_with_self_arg(self):
+        self.spy.class_method_with_self_arg(2)
+        assert_that(self.spy.class_method_with_self_arg, called().with_args(2))
 
 
 class BuiltinSpyTests(TestCase):
@@ -1857,6 +1866,10 @@ class Collaborator:
 
     @classmethod
     def class_method_with_args(cls, *args):
+        pass
+
+    @classmethod
+    def class_method_with_self_arg(cls, self):
         pass
 
     def method_with_cls_as_arg(self, cls):


### PR DESCRIPTION
Current implementation does two things that causes classmethods to fail:
1. Forwards `cls` to the bound method signature, so assertion never match because the first argument is `type(collaborator)`.
2. Adds `None` to `getcallargs`, which will always cause a TypeError e.g: 
`TypeError: Collaborator.class_method() takes n positional argument but n+1 were given`

I took care to not break methods that accepts `cls` as an arg when unrelated to `@classmethod`.