### PR TITLE
docs/test: Include docs & doctests in CI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+_build
 eggs
 parts
 bin
@@ -26,6 +27,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+
+doctests/*.inc
 
 # Translations
 *.mo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/async-spies.rst
+++ b/docs/async-spies.rst
@@ -1,4 +1,4 @@
-.. async_mode:
+.. _async_mode:
 
 Asynchronous spies
 ==================
@@ -17,7 +17,7 @@ Something like that:
 
    class Collaborator(object):
        def write(self, data):
-           print "your code here"
+           print("your code here")
 
    class SUT(object):
        def __init__(self, collaborator):

--- a/docs/async-spies.rst.test
+++ b/docs/async-spies.rst.test
@@ -17,7 +17,7 @@ Something like that:
 
    class Collaborator(object):
        def write(self, data):
-           print "your code here"
+           print("your code here")
 
    class SUT(object):
        def __init__(self, collaborator):

--- a/docs/async-spies.rst.test
+++ b/docs/async-spies.rst.test
@@ -1,4 +1,4 @@
-.. async_mode:
+.. _async_mode:
 
 Asynchronous spies
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/doubles.rst.test
+++ b/docs/doubles.rst.test
@@ -248,13 +248,14 @@ sequence does not match, an AssertionError is raised. "free" mocks are provided 
 .. testcode::
 .. sourcecode:: python
 
-   from doublex import Mock, assert_that, verify
+   from doublex import ANY_ARG, Mock, assert_that, verify
 
    with Mock() as smtp:
        smtp.helo()
        smtp.mail(ANY_ARG)
        smtp.rcpt("bill@apple.com")
-       smtp.data(ANY_ARG).returns(True).times(2)
+       smtp.data(ANY_ARG)
+       smtp.data(ANY_ARG)
 
    smtp.helo()
    smtp.mail("poormen@home.net")

--- a/doctests/Makefile
+++ b/doctests/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/doctests/conf.py
+++ b/doctests/conf.py
@@ -120,7 +120,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py36, py37, py38, py39, py310, docs
 
 [testenv]
 deps=nose2
@@ -11,7 +11,15 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310
+    3.10: py310, docs
+
+[testenv:docs]
+allowlist_externals = make
+deps = sphinx
+commands =
+    make -C docs
+    make -C doctests
+
 
 # using 2to3 with nose
 #:https://bitbucket.org/kumar303/fudge/src/9cafce359a21/tox.ini#cl-26


### PR DESCRIPTION
#15 :heavy_check_mark:

Unsure if doctests should be ran each version or not. I figured being able to build them on python 3.10 is good enough.