### PR TITLE
fix: Support namedtuple property stubbing for python 3.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 - Allow using called().with_some_args() with type-hinted arguments
 - Fix deprecation warnings
 - Mock support for classmethods on instances
+- Fix namedtuple support for python 3.8 and newer
 
 20190405
 ========

--- a/doublex/internal.py
+++ b/doublex/internal.py
@@ -505,6 +505,7 @@ class AttributeFactory(object):
         # -- python3 --
         method             = Method,
         function           = Method,
+        _tuplegetter       = Property,
         )
 
     @classmethod

--- a/doublex/proxy.py
+++ b/doublex/proxy.py
@@ -17,9 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-import sys
 import inspect
+from typing import NamedTuple
 
 try:
     from inspect import getcallargs
@@ -48,7 +47,7 @@ class Proxy(object):
         return None
 
     def get_signature(self, method_name):
-        if self.is_property(method_name):
+        if self.is_property(method_name) or self.is_namedtuple_field(method_name):
             return PropertySignature(self, method_name)
 
         if not self.is_method_or_func(method_name):
@@ -59,6 +58,13 @@ class Proxy(object):
     def is_property(self, attr_name):
         attr = getattr(self.collaborator_class, attr_name)
         return isinstance(attr, property)
+
+    def collaborator_is_namedtuple(self):
+        return issubclass(self.collaborator_class, tuple) and hasattr(self.collaborator_class, '_fields')
+
+    def is_namedtuple_field(self, attr_name):
+        attr = getattr(self.collaborator_class, attr_name)
+        return self.collaborator_is_namedtuple() and type(attr).__name__ == '_tuplegetter'
 
     def is_method_or_func(self, method_name):
         func = getattr(self.collaborator, method_name)

--- a/doublex/test/namedtuple_stub_tests.py
+++ b/doublex/test/namedtuple_stub_tests.py
@@ -1,0 +1,36 @@
+from typing import NamedTuple
+from unittest import TestCase
+
+from doublex import Stub, Spy, assert_that, property_got, called
+from hamcrest import is_
+
+
+class NamedtupleCollaborator(NamedTuple):
+    a: str
+    b: int
+
+    def method(self, arg):
+        pass
+
+
+class NamedtupleStubTests(TestCase):
+    def test_can_stub_namedtuple(self):
+        with Stub(NamedtupleCollaborator) as stub:
+            stub.a.returns('hi')
+            stub.method(5).returns('Nothing')
+
+        assert_that(stub.a, is_('hi'))
+        assert_that(stub.method(5), is_('Nothing'))
+
+
+class NamedtupleSpyTests(TestCase):
+    def test_can_spy_namedtuple(self):
+        with Spy(NamedtupleCollaborator) as spy:
+            spy.a.returns('hi')
+            spy.method(5).returns('Nothing')
+
+        _ = spy.a
+        spy.method(5)
+
+        assert_that(spy, property_got('a'))
+        assert_that(spy.method, called().with_args(5).times(1))


### PR DESCRIPTION
python3.8 and newer changed `namedtuple` from using `builtins.property` to a specialized `_collections._tuplegetter`. The new test cases fail on python 3.8+ without the extra collaborator inspections.