### PR TITLE
fix: Make property stubbing with `when()` work in python 3.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Fix deprecation warnings
 - Mock support for classmethods on instances
 - Fix namedtuple support for python 3.8 and newer
+- Fix issue with property stubbing using when() leaving stubs in setting up state
 
 20190405
 ========

--- a/doublex/internal.py
+++ b/doublex/internal.py
@@ -22,6 +22,8 @@
 import sys
 import threading
 import functools
+from enum import Enum
+
 import six
 
 if sys.version_info > (3, 3):
@@ -46,16 +48,19 @@ class WrongApiUsage(Exception):
     pass
 
 
-class Constant(str):
+class Constant(str, Enum):
+    ANY_ARG = 'ANY_ARG'
+    UNSPECIFIED = 'UNSPECIFIED'
+
+    def __str__(self):
+        return self.value
+
     def __repr__(self):
         return str(self)
 
-    def __eq__(self, other):
-        return self is other
 
-
-ANY_ARG = Constant('ANY_ARG')
-UNSPECIFIED = Constant('UNSPECIFIED')
+ANY_ARG = Constant.ANY_ARG
+UNSPECIFIED = Constant.UNSPECIFIED
 
 
 def add_indent(text, indent=0):

--- a/doublex/internal.py
+++ b/doublex/internal.py
@@ -58,6 +58,8 @@ class Constant(str, Enum):
     def __repr__(self):
         return str(self)
 
+    def is_in(self, container):
+        return any(item is self for item in container)
 
 ANY_ARG = Constant.ANY_ARG
 UNSPECIFIED = Constant.UNSPECIFIED
@@ -289,7 +291,7 @@ class InvocationContext(object):
         except ValueError:
             pass
 
-        if ANY_ARG in kargs.values():
+        if ANY_ARG.is_in(kargs.values()):
             raise WrongApiUsage(ANY_ARG_CAN_BE_KARG + ANY_ARG_DOC)
 
     def apply_on(self, method):
@@ -356,7 +358,7 @@ class InvocationContext(object):
         return retval
 
     def matches(self, other):
-        if ANY_ARG in self.args:
+        if ANY_ARG.is_in(self.args):
             matcher, actual = self, other
         else:
             matcher, actual = other, self
@@ -393,7 +395,7 @@ class InvocationContext(object):
         return retval
 
     def __lt__(self, other):
-        if ANY_ARG in other.args or self.args < other.args:
+        if ANY_ARG.is_in(other.args) or self.args < other.args:
             return True
 
         return sorted(self.kargs.items()) < sorted(other.kargs.items())

--- a/doublex/proxy.py
+++ b/doublex/proxy.py
@@ -224,7 +224,7 @@ class MethodSignature(Signature):
         return retval
 
     def assure_matches(self, context):
-        if ANY_ARG in context.args:
+        if ANY_ARG.is_in(context.args):
             return
 
         try:

--- a/doublex/test/any_arg_tests.py
+++ b/doublex/test/any_arg_tests.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from doublex import Stub, Spy, when
-from hamcrest import assert_that, anything, is_
+from doublex import Stub, Spy, when, called, ANY_ARG
+from hamcrest import assert_that, anything, is_, instance_of
 
 
 class CollaboratorWithProperty:
@@ -15,6 +15,11 @@ class Collaborator:
         pass
 
 
+class RaisingEq:
+    def __eq__(self, other):
+        raise ValueError('I dont like comparisons')
+
+
 class AnyArgTests(TestCase):
     def test_any_arg_matches_property(self):
         prop_stub = Spy(CollaboratorWithProperty)
@@ -25,3 +30,10 @@ class AnyArgTests(TestCase):
 
         assert_that(stub.method_accepting_property(prop_stub.prop), is_(2))
         assert prop_stub.prop == 5
+
+    def test_any_arg_checking_works_when_eq_raises(self):
+        with Spy(Collaborator) as spy:
+            spy.method_accepting_property(ANY_ARG).returns(6)
+
+        assert_that(spy.method_accepting_property(RaisingEq()), is_(6))
+        assert_that(spy.method_accepting_property, called().with_args(instance_of(RaisingEq)))

--- a/doublex/test/any_arg_tests.py
+++ b/doublex/test/any_arg_tests.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from doublex import Stub, Spy, when
+from hamcrest import assert_that, anything, is_
+
+
+class CollaboratorWithProperty:
+    @property
+    def prop(self):
+        pass
+
+
+class Collaborator:
+    def method_accepting_property(self, prop):
+        pass
+
+
+class AnyArgTests(TestCase):
+    def test_any_arg_matches_property(self):
+        prop_stub = Spy(CollaboratorWithProperty)
+        when(prop_stub).prop.returns(5)
+
+        with Stub(Collaborator) as stub:
+            stub.method_accepting_property(prop=anything()).returns(2)
+
+        assert_that(stub.method_accepting_property(prop_stub.prop), is_(2))
+        assert prop_stub.prop == 5

--- a/doublex/test/unit_tests.py
+++ b/doublex/test/unit_tests.py
@@ -1611,6 +1611,18 @@ class when_tests(TestCase):
         when(spy).one_arg_method(all_of(starts_with('h'), instance_of(str))).returns(1000)
         assert_that(spy.one_arg_method('hello'), is_(1000))
 
+    def test_stub_when_can_get_property(self):
+        stub = Stub(ObjCollaborator)
+        when(stub).prop_deco_readonly.returns(5)
+
+        assert_that(stub.prop_deco_readonly, is_(5))
+
+    def test_stub_when_can_set_property(self):
+        stub = Stub(ObjCollaborator)
+        when(stub).prop = 5
+
+        assert_that(stub.prop, is_(5))
+
 
 class expect_call_tests(TestCase):
     def test_expect_call(self):


### PR DESCRIPTION
- Make `Constant` an `Enum` to ensure equality check is more robust than the custom `__eq__`. This causes property stubbing with `when()` not to crash on python 3.8+.
- Correct bug in `Property(Observable)` not respecting the `_deactivate` flag like `Method(Observable)` does. This is a bug in all doublex versions. The fix make property stubbing with `when()` behave as expected.