### PR TITLE
Stop installing README.rst to sys.prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ config = dict(
     author_email     = 'David.Villa@gmail.com, david@parsson.se',
     url              = 'https://github.com/DavidVilla/python-doublex',
     packages         = ['doublex'],
-    data_files       = [('', ['README.rst'])],
     test_suite       = 'doublex.test',
     license          = 'GPLv3',
     long_description = local_open('README.rst').read(),


### PR DESCRIPTION
Remove the `data_files` entry in `setup.py` that caused the `README.rst` file being installed into `sys.prefix` (i.e. as `/usr/README.rst`). This definitely isn't a correct location for documentation.